### PR TITLE
Voxel scenes are not centered anymore

### DIFF
--- a/src/model/mesh.rs
+++ b/src/model/mesh.rs
@@ -9,7 +9,7 @@ use bevy::{
 use block_mesh::{greedy_quads, GreedyQuadsBuffer, RIGHT_HANDED_Y_UP_CONFIG};
 use ndshape::Shape;
 
-use super::{voxel::VisibleVoxel, VoxelData, VoxelQueryable};
+use super::{voxel::VisibleVoxel, VoxelData};
 
 pub(crate) fn mesh_model(voxels: &[VisibleVoxel], data: &VoxelData) -> Mesh {
     let mut greedy_quads_buffer = GreedyQuadsBuffer::new(data.shape.size() as usize);
@@ -22,9 +22,8 @@ pub(crate) fn mesh_model(voxels: &[VisibleVoxel], data: &VoxelData) -> Mesh {
         &quads_config.faces,
         &mut greedy_quads_buffer,
     );
-    let half_extents = data.model_size() * 0.5; // center the mesh
     let leading_padding = (data.padding() / 2) as f32 * data.voxel_size; // corrects the 1 offset introduced by the meshing.
-    let position_offset = half_extents + Vec3::splat(leading_padding);
+    let position_offset = Vec3::splat(leading_padding);
 
     let num_indices = greedy_quads_buffer.quads.num_quads() * 6;
     let num_vertices = greedy_quads_buffer.quads.num_quads() * 4;


### PR DESCRIPTION
Voxel meshes are not centered at their half-extent anymore.

For my use-case this seems more reasonable: I want the asset to be "grounded", so I would have to write some hefty systems accessing the AABB and wrapping the voxel scenes in additional transform nodes, since I don't have access to the voxel scene extent otherwise.

I am not sure if there are other use-cases where centering the voxel asset is preferred, but if so, maybe an addition to `VoxLoaderSettings` is appropriate. I tried this initially, but the `remesh` function is also called where it does not have access to the global settings, so I dropped this approach.